### PR TITLE
Fix to check for existing ghosts as well.

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -99,7 +99,7 @@ local function setEndingTransportLine(event, config)
     logging.log("build line with config: " .. serpent.line(config))
     local surface = player.surface
     local function canPlace(position)
-        return surface.can_place_entity { name = "transport-belt", position = position }
+        return surface.can_place_entity { name = "transport-belt", position = position, build_check_type = defines.build_check_type.ghost_place }
     end
     local function place(entity)
         entity = Copy.deep_copy(entity)

--- a/transport_line_connector.lua
+++ b/transport_line_connector.lua
@@ -347,7 +347,13 @@ function TransportLineConnector:testCanPlace(entity, cumulativeDistance, minDist
         for testDiff = 1, undergroundDistance - 1, 1 do
             local testPos = entity.position + Vector2D.fromDirection(entity.direction):scale(testDiff)
             local entityInMiddle = self.getEntityFunc(testPos)
-            if entityInMiddle and ((entity.direction or defines.direction.north) - entity.direction) % 4 == 0 and entityInMiddle.name == entity.name then
+            if entityInMiddle
+                and ((entity.direction or defines.direction.north) - entity.direction) % 4 == 0
+                and (
+                        entityInMiddle.name == entity.name or
+                        (entityInMiddle.type =="entity-ghost" 
+                            and entityInMiddle.ghost_name == entity.name)
+                ) then
                 return false
             end
         end


### PR DESCRIPTION
Hello, I'm the obnoxious guy from the mod page forum :)

I have added a quick fix to also check for existing ghost entities in the "canPlace" function and I also added checks for those ghosts in the TransportLineConnector:testCanPlace function which are the only places where those checks are performed.

I did some quick testing and is seems to place ghosts correctly even if there are some that haven't been built yet.

What do you think about these changes? Did I miss something?

All the best,
Chris